### PR TITLE
set arial as a font only in non-linux systems

### DIFF
--- a/GetDihe.py
+++ b/GetDihe.py
@@ -12,7 +12,10 @@ from rama_config import RAMA_PREFERENCES
 from rama_config import ROTA_PREFERENCES
 
 mpl.rcParams['pdf.fonttype'] = 42
-mpl.rcParams['font.sans-serif'] = 'arial'
+if sys.platform == "linux":
+	mpl.rcParams['font.sans-serif'] = 'Dejavu Sans'
+else:
+	mpl.rcParams['font.sans-serif'] = 'arial'
 mpl.rcParams['font.size'] = 10
 mpl.rcParams['axes.linewidth'] = 1.0
 mpl.rcParams['xtick.major.width'] = 1.0


### PR DESCRIPTION
Use common Sans fonts in linux systems. Arial is a proprietary font and not usually present in linux systems.

When the font is missing, matplotlib generates hundreds of lines of warnings and makes for poor user experience.