### PR TITLE
use regex to ignore commented line

### DIFF
--- a/CYANApra.py
+++ b/CYANApra.py
@@ -611,7 +611,7 @@ phir, chir = [],[]
 for aco in dihed:
 	for line in open(aco):
 		if line.split():
-			if line.startswith('#'):
+			if re.match('^\s*#', line):
 				continue
 			else:
 				total+=1


### PR DESCRIPTION
This change will avoid situations like this - 

```
 ## PHE CHI

## 240 PHE   CHI1    280.0   330.0 
```

I saw cyanapra failing when processing someone's dihed.aco file earlier today.