### PR TITLE
Allow adding comments in CALC.cya file with the word peaks

### DIFF
--- a/CYANApra.py
+++ b/CYANApra.py
@@ -120,7 +120,7 @@ if not os.path.exists(noadir):
 	os.makedirs(noadir)
 checkcons = open(outdir + outname + '_summary.txt','w')
 ## open the CALC.cya file to get the peaks list and additional constraint files used in the calculation. 
-cya_plists = [line.strip().replace('.peaks','') for line in open(calc).readlines() if line.strip() and 'peaks' in line][0].split()[2].split(',')
+cya_plists = [line.strip().replace('.peaks','') for line in open(calc).readlines() if line.strip() and 'peaks' in line and not re.match('^\s*#', line)][0].split()[2].split(',')
 lengths,upllengths = [], []
 for plist in cya_plists:
 	lengths.append(len(plist))

--- a/noa_analysis.py
+++ b/noa_analysis.py
@@ -23,7 +23,7 @@ AAA_dict = {"ALA": "A", "ARG": "R", "ASN": "N", "ASP": "D", "CYS": "C", "GLU": "
 
 
 def analize_noa(cwd, outdir, calc, noa7, Seqdict, violdict, qupldict,upldict,pad,upldict2):
-	cya_plists = [line.strip() for line in open(calc).readlines() if line.strip() and 'peaks' in line][0].split()[2].split(',')
+	cya_plists = [line.strip() for line in open(calc).readlines() if line.strip() and 'peaks' in line and not re.match('^\s*#', line)][0].split()[2].split(',')
 	prots = [line.strip() for line in open(calc).readlines() if line.strip() and 'prot' in line][0].split()[2].split(',')
 	log = glob.glob(os.path.join(cwd + 'log*'))[0]
 	header = [ '### UPL: Peak was idenitified in the output.upl file\n',


### PR DESCRIPTION
If CALC.cya file has comments as show below, cyanapra and noa_analysis will fail.

```
# names of NOESY peak lists

# (1) EphB2_CDN_Hall-NHn.peaks
# (2) EphB2_ARO_Ca-CmHm.peaks
# (3) EphB2_ARO_Hall-CaHa.peaks
# (4) EphB2_ARO_Hall-CmHm.peaks
# (5) EphB2_ARO_Hall-NHn.peaks
# (5) EphB2_MET_Cm-CmHm.peaks
# (6) EphB2_MET_N-CmHm.peaks

peaks       := EphB2_CDN_Hall-NHn.peaks,EphB2_ARO_Ca-CmHm.peaks, _<...>_

```

This commit allows processing only uncommented lines when parsing through CALC.cya file to generate list of peak files.